### PR TITLE
[zigbee2mqtt] Allow to specify app version in values

### DIFF
--- a/zigbee2mqtt/Chart.yaml
+++ b/zigbee2mqtt/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.4
+version: 0.1.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/zigbee2mqtt/templates/deployment.yaml
+++ b/zigbee2mqtt/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ tpl .Values.image.tag . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
           - name: TZ

--- a/zigbee2mqtt/values.yaml
+++ b/zigbee2mqtt/values.yaml
@@ -9,6 +9,7 @@ strategyType: Recreate
 image:
   repository: koenkk/zigbee2mqtt
   pullPolicy: IfNotPresent
+  tag: "{{ .Chart.AppVersion }}"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
This allows to override image tag from values. It can be useful in order to run versions that do not match `appVersion`, like `latest` or `latest-dev`.